### PR TITLE
minor changes, mostly grammatical

### DIFF
--- a/nerd_herder/templates/code-of-conduct-reporting-guide.html
+++ b/nerd_herder/templates/code-of-conduct-reporting-guide.html
@@ -12,7 +12,8 @@
                             In any PuPPy space (events or online), if you believe someone
                             is violating the <a href="/pages/code-of-conduct">Code of Conduct</a>,
                             we ask that you report it to the staff by emailing
-                            <a href="mailto:conduct@pspython.com">conduct@pspython.com</a>.
+                            <a href="mailto:conduct@pspython.com">conduct@pspython.com</a>
+                            or reporting to a staff person in person, if possible.
                             All reports will be kept confidential. In some cases we may
                             determine that a public statement will need to be made. If that’s
                             the case, the identities of all victims and reporters will remain

--- a/nerd_herder/templates/code-of-conduct-response-playbook.html
+++ b/nerd_herder/templates/code-of-conduct-response-playbook.html
@@ -49,8 +49,8 @@
 
                         <p>
                             If the reporter desires it, arrange for an escort by volunteer staff,
-                            venue
-                            staff, or a trusted person, contact a friend, and contact local law
+                            venue staff or a trusted person, to contact a friend, and/or to 
+                            contact local law
                             enforcement. Do not pressure the reporter to take any action if
                             they do not want to do it. Respect the reporter’s privacy by not
                             sharing unnecessary details with others, especially individuals who

--- a/nerd_herder/templates/code_of_conduct.html
+++ b/nerd_herder/templates/code_of_conduct.html
@@ -156,7 +156,7 @@
                             </li>
 
                             <li>
-                                Any other forums created by the community used for
+                                Any other forums created by the community and used for
                                 communication.
                             </li>
                         </ul>
@@ -201,7 +201,7 @@
                             but if
                             you missed the introduction or cannot find a staff member please reach
                             out
-                            to one of the staff members listed on the
+                            to one of the staff members listed in the
                             <a href="/pages/code-of-conduct/reporting-guide">Reporting Guide</a>.
                         </p>
 


### PR DESCRIPTION
It occurs to me that you may have meant that you always want reporters to file a written report in an email, regardless of whether they also speak to a staff member. If this is the case, we should write that explicitly. Otherwise, I just thought it was weird to only mention first thing that they should file a report even though you were addressing both online and in-person spaces.